### PR TITLE
Adso/stringstrip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build
 *.egg-info
 __pycache__
+/.vs

--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ from openehpy import client
 openehr_server = client.server_connection("https://openehr-server","utf-8-sig")
 aql = """
 select
-    c/content[openEHR-EHR-OBSERVATION.blood_pressure.v1]/data[at0001]/events[at0006]/time/value as datetime,
-    c/content[openEHR-EHR-OBSERVATION.blood_pressure.v1]/data[at0001]/events[at0006]/data[at0003]/items[at0004]/value/magnitude AS systolic,
-    c/content[openEHR-EHR-OBSERVATION.blood_pressure.v1]/data[at0001]/events[at0006]/data[at0003]/items[at0005]/value/magnitude AS diastolic
+    o/data[at0001]/events[at0006]/time/value as datetime,
+    o/data[at0001]/events[at0006]/data[at0003]/items[at0004]/value/magnitude AS systolic,
+    o/data[at0001]/events[at0006]/data[at0003]/items[at0005]/value/magnitude AS diastolic
 from
     composition c
-    contains observation o[openEHR-EHR-OBSERVATION.blood_pressure.v1]
+        contains observation o[openEHR-EHR-OBSERVATION.blood_pressure.v1]
 limit 5"""
 
-response = openehr_server.query(aql);
+response = openehr_server.query(aql)
 
 print(response)
 
@@ -41,6 +41,11 @@ openehr_server = client.server_connection("https://openehr-server","utf-8-sig", 
 
 when you create the openEHR server object for querying. 
 
+If you want to add headers you can pass in `headers = {"key":"value"}`
+
+```
+openehr_server = client.server_connection("https://openehr-server", headers = {"key":"value"})
+```
 
 # Build and install 
 

--- a/openehpy/client.py
+++ b/openehpy/client.py
@@ -1,5 +1,6 @@
 import requests
 import pandas
+import unicodedata
 
 class server_connection:
     def __init__(self, EHRStoreURL, responseEncoding = 'utf-8-sig',headers = None, verifySSLConnection = True):
@@ -11,7 +12,7 @@ class server_connection:
     def query(self, query):
         response = requests.post(
           self.EHRStoreURL + '/openehr/v1/query/aql/',
-          json = { 'q': query },
+          json = { 'q': server_connection.remove_control_characters(query) },
           verify = self.verifySSLConnection,
           headers = self.headers
           )
@@ -23,3 +24,7 @@ class server_connection:
         for column in resultset['columns']:
             columnNames.append(column['name'])
         return pandas.DataFrame(resultset['rows'], columns=columnNames) if 'rows' in resultset else resultset
+    
+    def remove_control_characters(s):
+        new_string = "".join(ch for ch in s if unicodedata.category(ch)[0]!="C")
+        return " ".join(new_string.split());

--- a/openehpy/client.py
+++ b/openehpy/client.py
@@ -2,13 +2,19 @@ import requests
 import pandas
 
 class server_connection:
-    def __init__(self, EHRStoreURL, responseEncoding = 'utf-8-sig', verifySSLConnection = True):
+    def __init__(self, EHRStoreURL, responseEncoding = 'utf-8-sig',headers = None, verifySSLConnection = True):
         self.EHRStoreURL = EHRStoreURL
         self.responseEncoding = responseEncoding
         self.verifySSLConnection = verifySSLConnection
+        self.headers = headers
 
     def query(self, query):
-        response = requests.post(self.EHRStoreURL + '/openehr/v1/query/aql/', json = { 'q': query }, verify = self.verifySSLConnection)
+        response = requests.post(
+          self.EHRStoreURL + '/openehr/v1/query/aql/',
+          json = { 'q': query },
+          verify = self.verifySSLConnection,
+          headers = self.headers
+          )
         response.encoding = self.responseEncoding
         return self.ResultsetAsDataFrame(response.json()) if response.ok else response
 

--- a/tests/testopenehpy.py
+++ b/tests/testopenehpy.py
@@ -4,7 +4,7 @@ from openehpy import client
 class Test_testPyOpenEHR(unittest.TestCase):
 
     def setUp(self):
-        openEHREndpoint = "https://vt-diag-srv01.dips.local:4443"
+        openEHREndpoint = "https://localhost:4443"
         self.connection = client.server_connection(openEHREndpoint,"utf-8-sig", verifySSLConnection = False)
 
     def tearDown(self):

--- a/tests/testopenehpy.py
+++ b/tests/testopenehpy.py
@@ -4,8 +4,8 @@ from openehpy import client
 class Test_testPyOpenEHR(unittest.TestCase):
 
     def setUp(self):
-        openEHREndpoint = "https://localhost:4443"
-        self.connection = client.server_connection(openEHREndpoint,"utf-8-sig", False)
+        openEHREndpoint = "https://vt-diag-srv01.dips.local:4443"
+        self.connection = client.server_connection(openEHREndpoint,"utf-8-sig", verifySSLConnection = False)
 
     def tearDown(self):
         self.connection = ""

--- a/tests/testregex.py
+++ b/tests/testregex.py
@@ -17,7 +17,6 @@ class Test_regex(unittest.TestCase):
             composition c
             contains observation o[openEHR-EHR-OBSERVATION.blood_pressure.v1]"""
         sanitized = """select o/data[at0001]/events[at0006]/time/value as datetime, o/data[at0001]/events[at0006]/data[at0003]/items[at0004]/value/magnitude AS systolic, o/data[at0001]/events[at0006]/data[at0003]/items[at0005]/value/magnitude AS diastolic from composition c contains observation o[openEHR-EHR-OBSERVATION.blood_pressure.v1]"""
-        test = client.server_connection.remove_control_characters(unsanitized)
         self.assertEqual(client.server_connection.remove_control_characters(unsanitized), sanitized)
 if __name__ == '__main__':
     unittest.main()

--- a/tests/testregex.py
+++ b/tests/testregex.py
@@ -1,0 +1,23 @@
+import unittest
+from openehpy import client
+
+class Test_regex(unittest.TestCase):
+
+    def test_remove_control_char(self):
+        unsanitized = 'abc\r\0\t\n,[]'
+        sanitized = 'abc,[]'
+        self.assertEqual(client.server_connection.remove_control_characters(unsanitized),sanitized)
+
+    def test_remove_control_char_from_SQL(self):
+        unsanitized = """select
+            o/data[at0001]/events[at0006]/time/value as datetime,
+            o/data[at0001]/events[at0006]/data[at0003]/items[at0004]/value/magnitude AS systolic,
+            o/data[at0001]/events[at0006]/data[at0003]/items[at0005]/value/magnitude AS diastolic
+             from
+            composition c
+            contains observation o[openEHR-EHR-OBSERVATION.blood_pressure.v1]"""
+        sanitized = """select o/data[at0001]/events[at0006]/time/value as datetime, o/data[at0001]/events[at0006]/data[at0003]/items[at0004]/value/magnitude AS systolic, o/data[at0001]/events[at0006]/data[at0003]/items[at0005]/value/magnitude AS diastolic from composition c contains observation o[openEHR-EHR-OBSERVATION.blood_pressure.v1]"""
+        test = client.server_connection.remove_control_characters(unsanitized)
+        self.assertEqual(client.server_connection.remove_control_characters(unsanitized), sanitized)
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
fixes #1 #2 
* Added support for http headers using : `openehr_server = client.server_connection("https://openehr-server", headers = {"key":"value"})`
* Remove newlines and unnecessary whitespaces from AQL query
* Simplify example AQL in `README.md`